### PR TITLE
Fix audio inference - Pass --level 0 to audio feature extractor, and improve error handling

### DIFF
--- a/src/demo/multimodial_demo.py
+++ b/src/demo/multimodial_demo.py
@@ -371,7 +371,7 @@ def audio_inference(clip: str, coeffs: list):
     if osp.exists(out_audio):
         verbose_print(f'Generated WAV for clip {clip}', style='yellow')
     else:
-        verbose_print(f'FAILED to generated Wav for some reason for clip {clip}', style='yellow')
+        verbose_print(f'FAILED to generate WAV for some reason for clip {clip}', style='yellow')
         PREDS[clip]['audio'] = placeholder
         return
 
@@ -390,7 +390,7 @@ def audio_inference(clip: str, coeffs: list):
     if osp.exists(out_feature):
         verbose_print(f'Generated audio feature for clip {clip}', style='yellow')
     else:
-        verbose_print(f'FAILED to generated feature file for some reason for clip {clip}', style='yellow')
+        verbose_print(f'FAILED to generate feature file for some reason for clip {clip}', style='yellow')
         PREDS[clip]['audio'] = placeholder
         return
 


### PR DESCRIPTION
I found that the audio inference stage was failing due to a misleading error about Python type mismatches on the 'video' parameter - turned out the .npy file was not being created because the `--level 1` default was being interpreted very lierally by the aduo feature extractore script. Passing an explict `--level 0` resolved the issue.

Also added some paranoid error checking around the intermediate file creation during audio inference.